### PR TITLE
fix copy ca.crt to nodes fails in non-default cluster name

### DIFF
--- a/roles/kubeadm-nodes/tasks/main.yaml
+++ b/roles/kubeadm-nodes/tasks/main.yaml
@@ -2,7 +2,7 @@
   file: path=/etc/kubernetes/pki/ state=directory
 
 - copy:
-    src: /tmp/k8s-master/etc/kubernetes/pki/ca.crt
+    src: /tmp/{{ name }}-master/etc/kubernetes/pki/ca.crt
     dest: /etc/kubernetes/pki/ca.crt
     mode: 0644
 


### PR DESCRIPTION
when using a non-default cluster name, the ansible script fails with

``` 
  TASK [kubeadm-nodes : copy] ***********************************************************************************************************************************************************************************************************
  Saturday 18 November 2017  12:40:26 +0100 (0:00:00.574)       0:00:56.549 *****
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AnsibleFileNotFound: Could not find or access '/tmp/k8s-master/etc/kubernetes/pki/ca.crt'
  fatal: [k8os-1]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find or access '/tmp/k8s-master/etc/kubernetes/pki/ca.crt'"}
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AnsibleFileNotFound: Could not find or access '/tmp/k8s-master/etc/kubernetes/pki/ca.crt'
  fatal: [k8os-2]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find or access '/tmp/k8s-master/etc/kubernetes/pki/ca.crt'"}
  An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AnsibleFileNotFound: Could not find or access '/tmp/k8s-master/etc/kubernetes/pki/ca.crt'
  fatal: [k8os-3]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find or access '/tmp/k8s-master/etc/kubernetes/pki/ca.crt'"}
``` 