### PR TITLE
quote password in cloud-config

### DIFF
--- a/files/cloud-config.j2
+++ b/files/cloud-config.j2
@@ -1,7 +1,7 @@
 [Global]
 auth-url = {{ lookup('env', 'OS_AUTH_URL') }}
 username = {{ lookup('env', 'OS_USERNAME') }}
-password = {{ lookup('env', 'OS_PASSWORD') }}
+password = "{{ lookup('env', 'OS_PASSWORD') }}"
 tenant-name = {{ lookup('env', 'OS_PROJECT_NAME') }}
 tenant-id = {{ lookup('env', 'OS_PROJECT_ID') }}
 {% if lookup('env', 'OS_REGION_NAME') != '' %}


### PR DESCRIPTION
if the password contains  the `#` character , kubelet does not start : 

``` 
failed to run Kubelet: could not init cloud provider "openstack": Authentication failed
``` 
probably because the password is cut and the rest is interpreted as comment.
quoting fixes it