### PR TITLE
update docker version to 1.13.1

### DIFF
--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -14,7 +14,7 @@
     state: installed
     update_cache: yes
   with_items:
-    - docker.io=1.12.6-0ubuntu1~16.04.1
+    - docker.io=1.13.1-0ubuntu1~16.04.2
     - kubelet=1.8.3-00
     - kubeadm=1.8.3-00
     - kubectl=1.8.3-00


### PR DESCRIPTION
not sure what the consequences are of changing the docker version. Just close is this one if it is too dangerous ...
Anyway, using 1.12.6 did not work for me, the playbook failed with : `E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found` 

I checked on the server, 1.12.6 is indeed not available:

```  
ubuntu@k8os-master:~$ apt-cache madison docker.io
 docker.io | 1.13.1-0ubuntu1~16.04.2 | http://ch.archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages
 docker.io | 1.10.3-0ubuntu6 | http://ch.archive.ubuntu.com/ubuntu xenial/universe amd64 Packages
``` 


Full ansible log: 
``` 
      TASK [kubeadm : Install docker and kubernetes packages] *******************************************************************************************************************************************************************************
      Saturday 18 November 2017  12:20:31 +0100 (0:00:00.953)       0:00:45.051 *****
      failed: [k8os-3] (item=[u'docker.io=1.12.6-0ubuntu1~16.04.1', u'kubelet=1.8.3-00', u'kubeadm=1.8.3-00', u'kubectl=1.8.3-00', u'kubernetes-cni=0.5.1-00']) => {"cache_update_time": 1511004032, "cache_updated": true, "changed": false, "failed": true, "item": ["docker.io=1.12.6-0ubuntu1~16.04.1", "kubelet=1.8.3-00", "kubeadm=1.8.3-00", "kubectl=1.8.3-00", "kubernetes-cni=0.5.1-00"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'docker.io=1.12.6-0ubuntu1~16.04.1' 'kubelet=1.8.3-00' 'kubeadm=1.8.3-00' 'kubectl=1.8.3-00' 'kubernetes-cni=0.5.1-00'' failed: E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "rc": 100, "stderr": "E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "stderr_lines": ["E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}
      failed: [k8os-2] (item=[u'docker.io=1.12.6-0ubuntu1~16.04.1', u'kubelet=1.8.3-00', u'kubeadm=1.8.3-00', u'kubectl=1.8.3-00', u'kubernetes-cni=0.5.1-00']) => {"cache_update_time": 1511004033, "cache_updated": true, "changed": false, "failed": true, "item": ["docker.io=1.12.6-0ubuntu1~16.04.1", "kubelet=1.8.3-00", "kubeadm=1.8.3-00", "kubectl=1.8.3-00", "kubernetes-cni=0.5.1-00"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'docker.io=1.12.6-0ubuntu1~16.04.1' 'kubelet=1.8.3-00' 'kubeadm=1.8.3-00' 'kubectl=1.8.3-00' 'kubernetes-cni=0.5.1-00'' failed: E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "rc": 100, "stderr": "E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "stderr_lines": ["E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}
      failed: [k8os-1] (item=[u'docker.io=1.12.6-0ubuntu1~16.04.1', u'kubelet=1.8.3-00', u'kubeadm=1.8.3-00', u'kubectl=1.8.3-00', u'kubernetes-cni=0.5.1-00']) => {"cache_update_time": 1511004033, "cache_updated": true, "changed": false, "failed": true, "item": ["docker.io=1.12.6-0ubuntu1~16.04.1", "kubelet=1.8.3-00", "kubeadm=1.8.3-00", "kubectl=1.8.3-00", "kubernetes-cni=0.5.1-00"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'docker.io=1.12.6-0ubuntu1~16.04.1' 'kubelet=1.8.3-00' 'kubeadm=1.8.3-00' 'kubectl=1.8.3-00' 'kubernetes-cni=0.5.1-00'' failed: E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "rc": 100, "stderr": "E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "stderr_lines": ["E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}
      failed: [k8os-master] (item=[u'docker.io=1.12.6-0ubuntu1~16.04.1', u'kubelet=1.8.3-00', u'kubeadm=1.8.3-00', u'kubectl=1.8.3-00', u'kubernetes-cni=0.5.1-00']) => {"cache_update_time": 1511004033, "cache_updated": true, "changed": false, "failed": true, "item": ["docker.io=1.12.6-0ubuntu1~16.04.1", "kubelet=1.8.3-00", "kubeadm=1.8.3-00", "kubectl=1.8.3-00", "kubernetes-cni=0.5.1-00"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'docker.io=1.12.6-0ubuntu1~16.04.1' 'kubelet=1.8.3-00' 'kubeadm=1.8.3-00' 'kubectl=1.8.3-00' 'kubernetes-cni=0.5.1-00'' failed: E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "rc": 100, "stderr": "E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found\n", "stderr_lines": ["E: Version '1.12.6-0ubuntu1~16.04.1' for 'docker.io' was not found"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information..."]}
``` 
      



